### PR TITLE
Add Keybinding class for mapping keys to actions

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -1,0 +1,9 @@
+" Vim format settings for Harvest Rogue code
+"
+" To use these settings automatically, add the following lines to your ~/.vimrc,
+" and launch Vim from the project root:
+"
+"    set exrc
+"    set secure
+
+autocmd FileType cpp set expandtab|set tabstop=3|set shiftwidth=3

--- a/include/input.h
+++ b/include/input.h
@@ -16,18 +16,7 @@
 #define HARVEST_ROGUE_INPUT_H
 
 #include <memory>
-
-#define IK_LEFT_ARROW  0404
-#define IK_UP_ARROW    0403
-#define IK_RIGHT_ARROW 0405
-#define IK_DOWN_ARROW  0402
-#define IK_SPACEBAR    ' '
-#ifdef WIN32
-	#define IK_RETURN_KEY  13
-#else
-	#define IK_RETURN_KEY  10
-#endif
-#define IK_ESCAPE      27
+#include "keybinding.h"
 
 class Input {
 private:
@@ -52,8 +41,11 @@ public:
 
    void DisableInputTimeout();
 
+   Action GetActionForKeyPress(int key);
+
 private:
    int InputTimeout;
+   Keybinding keybinding;
 };
 
 

--- a/include/keybinding.h
+++ b/include/keybinding.h
@@ -1,0 +1,55 @@
+/*
+    harvest-rogue is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    harvest-rogue is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with harvest-rogue.  If not, see <http://www.gnu.org/licenses/>.     */
+
+#ifndef HARVEST_ROGUE_KEYBINDING_H
+#define HARVEST_ROGUE_KEYBINDING_H
+
+#include <map>
+
+#define IK_LEFT_ARROW  0404
+#define IK_UP_ARROW    0403
+#define IK_RIGHT_ARROW 0405
+#define IK_DOWN_ARROW  0402
+#define IK_SPACEBAR    ' '
+#ifdef WIN32
+	#define IK_RETURN_KEY  13
+#else
+	#define IK_RETURN_KEY  10
+#endif
+#define IK_ESCAPE      27
+
+#define ACTION_UNASSIGNED -1
+#define ACTION_MOVE_UP 0
+#define ACTION_MOVE_DOWN 1
+#define ACTION_MOVE_LEFT 2
+#define ACTION_MOVE_RIGHT 3
+#define ACTION_OPEN_INVENTORY 4
+#define ACTION_OPEN_ACTION_LIST 5
+#define ACTION_GAME_MENU 6
+#define ACTION_USE_TOOL 7
+
+typedef int Action;
+
+class Keybinding {
+	public:
+		Keybinding();
+		~Keybinding();
+
+      Action GetAction(int key);
+
+   private:
+      std::map<int, Action> keybindings;
+};
+
+#endif // HARVEST_ROGUE_KEYBINDING_H

--- a/src/frontends/ncurses/input.cpp
+++ b/src/frontends/ncurses/input.cpp
@@ -16,6 +16,9 @@
 #include <curses.h>
 
 Input::Input() {
+   // TODO: How will a user's custom keybinding be loaded? External to this class or here?
+   this->keybinding = Keybinding();
+
    this->InputTimeout = -1;
    notimeout(stdscr, TRUE);
 #ifndef PDCURSES
@@ -43,4 +46,8 @@ int Input::GetInputTimeout() {
 
 void Input::DisableInputTimeout() {
    this->SetInputTimeout(-1);
+}
+
+Action Input::GetActionForKeyPress(int key) {
+   return this->keybinding.GetAction(key);
 }

--- a/src/keybinding.cpp
+++ b/src/keybinding.cpp
@@ -1,0 +1,49 @@
+/*
+    harvest-rogue is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    harvest-rogue is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with harvest-rogue.  If not, see <http://www.gnu.org/licenses/>.     */
+
+#include "keybinding.h"
+
+Keybinding::Keybinding() {
+   // Default keybindings
+   this->keybindings['a'] = ACTION_OPEN_ACTION_LIST;
+   this->keybindings['A'] = ACTION_OPEN_ACTION_LIST;
+   this->keybindings['i'] = ACTION_OPEN_INVENTORY;
+   this->keybindings['I'] = ACTION_OPEN_INVENTORY;
+
+   this->keybindings[IK_UP_ARROW] = ACTION_MOVE_UP;
+   this->keybindings[IK_DOWN_ARROW] = ACTION_MOVE_DOWN;
+   this->keybindings[IK_LEFT_ARROW] = ACTION_MOVE_LEFT;
+   this->keybindings[IK_RIGHT_ARROW] = ACTION_MOVE_RIGHT;
+   this->keybindings[IK_RETURN_KEY] = ACTION_GAME_MENU;
+   this->keybindings[IK_SPACEBAR] = ACTION_USE_TOOL;
+
+   // Vi-style movement this->keys
+   this->keybindings['j'] = ACTION_MOVE_DOWN;
+   this->keybindings['k'] = ACTION_MOVE_UP;
+   this->keybindings['l'] = ACTION_MOVE_RIGHT;
+   this->keybindings['h'] = ACTION_MOVE_LEFT;
+}
+
+Keybinding::~Keybinding() {
+}
+
+Action Keybinding::GetAction(int key) {
+   auto it = this->keybindings.find(key);
+
+   if (it == this->keybindings.end()) {
+      return ACTION_UNASSIGNED;
+   } else {
+      return it->second;
+   }
+}

--- a/src/scenes/game.cpp
+++ b/src/scenes/game.cpp
@@ -36,34 +36,37 @@ void Game::OnKeyPress(int key) {
       return;
    }
 
+   auto action = Input::Get().GetActionForKeyPress(key);
 
-   switch (key) {
-      case IK_RETURN_KEY:
+   switch (action) {
+      case ACTION_GAME_MENU:
          GameState::Get().PushDialog(GameMenuDialog::Construct());
          break;
-      case IK_UP_ARROW:
+      case ACTION_MOVE_UP:
          Player::Get().WalkPlayer(DirectionUp);
          break;
-      case IK_DOWN_ARROW:
+      case ACTION_MOVE_DOWN:
          Player::Get().WalkPlayer(DirectionDown);
          break;
-      case IK_LEFT_ARROW:
+      case ACTION_MOVE_LEFT:
          Player::Get().WalkPlayer(DirectionLeft);
          break;
-      case IK_RIGHT_ARROW:
+      case ACTION_MOVE_RIGHT:
          Player::Get().WalkPlayer(DirectionRight);
          break;
-      case IK_SPACEBAR:
+      case ACTION_USE_TOOL:
          Player::Get().UseTool();
          break;
-      case 'a':
-      case 'A':
+      case ACTION_OPEN_ACTION_LIST:
          GameState::Get().PushDialog(ActionDialog::Construct());
          break;
-      case 'i':
-      case 'I':
+      case ACTION_OPEN_INVENTORY:
          GameState::Get().PushDialog(InventoryDialog::Construct());
          break;
+      default:
+         std::stringstream invalidInputMessage;
+         invalidInputMessage << "Invalid input: '" << (char)key << "'";
+         GameState::Get().AddLogMessage(invalidInputMessage.str());
    }
 
    GameState::Get().StepSimulation();


### PR DESCRIPTION
This extra bit of abstraction should help with implementing configurable key bindings. I'm not sure if you'll want `Input` to own a `Keybinding` instance, but that seemed like a good way to do it for now.

I also included a project .vimrc to help out any collaborators who use Vim, since you're using 3 space indentation (you're one of those unicorns I read about on /r/programming! :laughing:).